### PR TITLE
clear list upon exiting list composition fragment

### DIFF
--- a/app/src/main/java/com/doublesp/coherence/datastore/DataStore.java
+++ b/app/src/main/java/com/doublesp/coherence/datastore/DataStore.java
@@ -100,6 +100,11 @@ public class DataStore implements DataStoreInterface {
     }
 
     @Override
+    public void clearIdeas() {
+        getIdeas().clear();
+    }
+
+    @Override
     public void setSuggestions(List<Idea> ideas) {
         getSuggestions().clear();
         getSuggestions().addAll(ideas);

--- a/app/src/main/java/com/doublesp/coherence/fragments/ListCompositionFragment.java
+++ b/app/src/main/java/com/doublesp/coherence/fragments/ListCompositionFragment.java
@@ -166,6 +166,7 @@ public class ListCompositionFragment extends DialogFragment {
     @Override
     public void onDetach() {
         super.onDetach();
+        mInteractor.clearIdeas();
     }
 
     void setupBackgroundImageId() {

--- a/app/src/main/java/com/doublesp/coherence/interactors/IdeaInteractorBase.java
+++ b/app/src/main/java/com/doublesp/coherence/interactors/IdeaInteractorBase.java
@@ -90,6 +90,13 @@ abstract public class IdeaInteractorBase implements IdeaInteractorInterface {
     }
 
     @Override
+    public void clearIdeas() {
+        mIdeaDataStore.setIdeaState(R.id.state_refreshing);
+        mIdeaDataStore.clearIdeas();
+        mIdeaDataStore.setIdeaState(R.id.state_loaded);
+    }
+
+    @Override
     abstract public void getSuggestions(String keyword);
 
     @Override

--- a/app/src/main/java/com/doublesp/coherence/interfaces/domain/DataStoreInterface.java
+++ b/app/src/main/java/com/doublesp/coherence/interfaces/domain/DataStoreInterface.java
@@ -30,6 +30,8 @@ public interface DataStoreInterface {
 
     void removeIdea(int pos);
 
+    void clearIdeas();
+
     void setSuggestions(List<Idea> ideas);
 
     void setGoals(List<Goal> goals);

--- a/app/src/main/java/com/doublesp/coherence/interfaces/domain/IdeaInteractorInterface.java
+++ b/app/src/main/java/com/doublesp/coherence/interfaces/domain/IdeaInteractorInterface.java
@@ -28,6 +28,8 @@ public interface IdeaInteractorInterface {
 
     void removeIdea(int pos);
 
+    void clearIdeas();
+
     void getSuggestions(String keyword);
 
     void subscribeIdeaStateChange(Observer<Integer> observer);


### PR DESCRIPTION
#84 
@santhoshsachindran 
clear list when list composition fragment is dismissed, so that you won't see old data when creating an empty list.