### PR TITLE
include rotating image for grocery lists

### DIFF
--- a/app/src/main/java/com/doublesp/coherence/activities/MainActivity.java
+++ b/app/src/main/java/com/doublesp/coherence/activities/MainActivity.java
@@ -285,10 +285,10 @@ public class MainActivity extends AppCompatActivity implements InjectorInterface
         listCompositionFragment.show(getSupportFragmentManager(), LIST_COMPOSITION_FRAGMENT);
     }
 
-    public void onIdeaSearchClick(View view) {
-        GoalSearchFragment searchResultFragment = GoalSearchFragment.newInstance();
-        searchResultFragment.setStyle(DialogFragment.STYLE_NORMAL, R.style.Dialog_FullScreen);
-        searchResultFragment.show(getSupportFragmentManager(), IDEA_SEARCH_RESULT_FRAGMENT);
+    public void onBookmarkClick(View view) {
+        SavedGoalsFragment savedGoalsFragment = SavedGoalsFragment.newInstance();
+        savedGoalsFragment.setStyle(DialogFragment.STYLE_NORMAL, R.style.Dialog_FullScreen);
+        savedGoalsFragment.show(getSupportFragmentManager(), IDEA_SEARCH_RESULT_FRAGMENT);
     }
 
     private void handleDeeplink() {

--- a/app/src/main/java/com/doublesp/coherence/adapters/HomeFragmentPagerAdapter.java
+++ b/app/src/main/java/com/doublesp/coherence/adapters/HomeFragmentPagerAdapter.java
@@ -1,6 +1,6 @@
 package com.doublesp.coherence.adapters;
 
-import com.doublesp.coherence.fragments.SavedGoalsFragment;
+import com.doublesp.coherence.fragments.GoalSearchFragment;
 import com.doublesp.coherence.fragments.SavedIdeasFragment;
 
 import android.content.Context;
@@ -14,7 +14,7 @@ import android.support.v4.app.FragmentPagerAdapter;
 
 public class HomeFragmentPagerAdapter extends FragmentPagerAdapter {
 
-    private String tabTitles[] = new String[]{"Saved Ideas", "Saved Recipes"};
+    private String tabTitles[] = new String[]{"Explore Recipes", "Saved Ideas"};
     private Context mContext;
 
     public HomeFragmentPagerAdapter(FragmentManager fm, Context context) {
@@ -26,9 +26,9 @@ public class HomeFragmentPagerAdapter extends FragmentPagerAdapter {
     public Fragment getItem(int position) {
         switch (position) {
             case 0:
-                return SavedIdeasFragment.newInstance();
+                return GoalSearchFragment.newInstance();
             default:
-                return SavedGoalsFragment.newInstance();
+                return SavedIdeasFragment.newInstance();
         }
     }
 

--- a/app/src/main/java/com/doublesp/coherence/fragments/GoalSearchFragment.java
+++ b/app/src/main/java/com/doublesp/coherence/fragments/GoalSearchFragment.java
@@ -15,8 +15,8 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.DialogFragment;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
@@ -32,7 +32,6 @@ import static com.doublesp.coherence.fragments.ListCompositionFragment.LIST_COMP
 public class GoalSearchFragment extends DialogFragment {
 
     static final String GOAL_SEARCH_FRAGMENT_VIEW_MODEL = "GOAL_SEARCH_FRAGMENT_VIEW_MODEL";
-    static final int GOAL_SEARCH_FRAGMENT_SPANS = 2;
     FragmentGoalSearchBinding binding;
     int[] mBackgroundImageIds;
     int mBackgroundImageIndex;
@@ -83,8 +82,7 @@ public class GoalSearchFragment extends DialogFragment {
                              Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater,
                 R.layout.fragment_goal_search, container, false);
-        binding.rvIdeaSearchResults.setLayoutManager(new StaggeredGridLayoutManager(
-                GOAL_SEARCH_FRAGMENT_SPANS, StaggeredGridLayoutManager.VERTICAL));
+        binding.rvIdeaSearchResults.setLayoutManager(new LinearLayoutManager(getContext()));
         binding.rvIdeaSearchResults.setAdapter(mAdapter);
         binding.etIdeaSearchBox.addTextChangedListener(new TextWatcher() {
             @Override
@@ -117,13 +115,9 @@ public class GoalSearchFragment extends DialogFragment {
 
     @Override
     public void onResume() {
-        // Get existing layout params for the window
-        ViewGroup.LayoutParams params = getDialog().getWindow().getAttributes();
-        // Assign window properties to fill the parent
-        params.width = WindowManager.LayoutParams.MATCH_PARENT;
-        params.height = WindowManager.LayoutParams.MATCH_PARENT;
-        getDialog().getWindow().setAttributes((android.view.WindowManager.LayoutParams) params);
-        // Call super onResume after sizing
+        if (getDialog() != null) {
+            updateLayoutParams();
+        }
         super.onResume();
     }
 
@@ -155,5 +149,14 @@ public class GoalSearchFragment extends DialogFragment {
                 rotateImage();
             }
         }, LIST_COMPOSITION_BACKGROUND_IMAGE_ROTATION_INTERVAL);
+    }
+
+    private void updateLayoutParams() {
+        // Get existing layout params for the window
+        ViewGroup.LayoutParams params = getDialog().getWindow().getAttributes();
+        // Assign window properties to fill the parent
+        params.width = WindowManager.LayoutParams.MATCH_PARENT;
+        params.height = WindowManager.LayoutParams.MATCH_PARENT;
+        getDialog().getWindow().setAttributes((android.view.WindowManager.LayoutParams) params);
     }
 }

--- a/app/src/main/java/com/doublesp/coherence/fragments/SavedGoalsFragment.java
+++ b/app/src/main/java/com/doublesp/coherence/fragments/SavedGoalsFragment.java
@@ -8,17 +8,18 @@ import com.doublesp.coherence.interfaces.presentation.InjectorInterface;
 import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
-public class SavedGoalsFragment extends Fragment {
+public class SavedGoalsFragment extends DialogFragment {
 
     FragmentSavedGoalsBinding binding;
     @Inject
@@ -55,7 +56,7 @@ public class SavedGoalsFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_saved_goals, container, false);
-        binding.rvSavedGoals.setLayoutManager(new StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL));
+        binding.rvSavedGoals.setLayoutManager(new LinearLayoutManager(getContext()));
         binding.rvSavedGoals.setAdapter(mAdapter);
         binding.rvSavedGoals.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
@@ -79,9 +80,26 @@ public class SavedGoalsFragment extends Fragment {
     }
 
     @Override
+    public void onResume() {
+        if (getDialog() != null) {
+            updateLayoutParams();
+        }
+        super.onResume();
+    }
+
+    @Override
     public void onDetach() {
         super.onDetach();
         mInteractor.loadBookmarkedGoals();
+    }
+
+    private void updateLayoutParams() {
+        // Get existing layout params for the window
+        ViewGroup.LayoutParams params = getDialog().getWindow().getAttributes();
+        // Assign window properties to fill the parent
+        params.width = WindowManager.LayoutParams.MATCH_PARENT;
+        params.height = WindowManager.LayoutParams.MATCH_PARENT;
+        getDialog().getWindow().setAttributes((android.view.WindowManager.LayoutParams) params);
     }
 
 }

--- a/app/src/main/java/com/doublesp/coherence/utils/ImageUtils.java
+++ b/app/src/main/java/com/doublesp/coherence/utils/ImageUtils.java
@@ -1,0 +1,38 @@
+package com.doublesp.coherence.utils;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.doublesp.coherence.R;
+
+import android.os.Handler;
+import android.widget.ImageView;
+
+import java.util.List;
+
+/**
+ * Created by pinyaoting on 11/29/16.
+ */
+
+public class ImageUtils {
+
+    public static void rotateImage(final Handler handler, final ImageView imageView, final List<String> imageUrls, final int imageIndex, final int interveral) {
+        Glide.with(imageView.getContext())
+                .load(imageUrls.get(imageIndex))
+                .fitCenter()
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .animate(R.anim.animation_idea_review)
+                .into(imageView);
+
+        // TODO: [Monetization] insert image ads in image rotation
+        if (imageUrls.size() < 2) {
+            return;
+        }
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                int newImageIndex = (imageIndex + 1) % imageUrls.size();
+                rotateImage(handler, imageView, imageUrls, newImageIndex, interveral);
+            }
+        }, interveral);
+    }
+}

--- a/app/src/main/res/layout/fragment_goal_preview.xml
+++ b/app/src/main/res/layout/fragment_goal_preview.xml
@@ -47,6 +47,7 @@ Salt, to taste" />
                 android:onClick="@{() -> handler.onCreateIdeaListClick(viewModel)}"
                 android:src="@drawable/ic_create"
                 android:tint="@color/colorButton"
+                android:backgroundTint="@color/colorAccent"
                 app:fabSize="normal"/>
 
     </FrameLayout>

--- a/app/src/main/res/layout/fragment_goal_search.xml
+++ b/app/src/main/res/layout/fragment_goal_search.xml
@@ -28,7 +28,19 @@
                 android:gravity="center"
                 android:hint="@string/idea_hint_search"
                 android:maxLines="1"
-                android:textColor="@color/colorPrimary"/>
+                style="@style/SearchBox"/>
+
+        <android.support.design.widget.FloatingActionButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|right|end"
+                android:layout_margin="16dp"
+                android:onClick="onBookmarkClick"
+                android:src="@drawable/ic_bookmark"
+                android:tint="@color/colorButton"
+                app:fabSize="normal"
+                app:layout_anchor="@id/rvIdeaSearchResults"
+                app:layout_anchorGravity="bottom|right|end"/>
 
     </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_list_composition.xml
+++ b/app/src/main/res/layout/fragment_list_composition.xml
@@ -35,10 +35,7 @@
                 android:gravity="center"
                 android:hint="@string/idea_hint_create"
                 android:maxLines="1"
-                android:textColor="@color/colorText"
-                android:textColorHint="@color/colorHint"
-                android:background="@drawable/border"
-                />
+                style="@style/SearchBox"/>
 
         <com.getbase.floatingactionbutton.FloatingActionsMenu
                 android:id="@+id/multiple_actions"

--- a/app/src/main/res/layout/fragment_saved_goals.xml
+++ b/app/src/main/res/layout/fragment_saved_goals.xml
@@ -27,18 +27,6 @@
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"/>
 
-        <android.support.design.widget.FloatingActionButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom|right|end"
-                android:layout_margin="16dp"
-                android:onClick="onIdeaSearchClick"
-                android:src="@drawable/ic_search"
-                android:tint="@color/colorButton"
-                app:fabSize="normal"
-                app:layout_anchor="@id/rvSavedGoals"
-                app:layout_anchorGravity="bottom|right|end"/>
-
     </FrameLayout>
 
 </layout>

--- a/app/src/main/res/layout/item_goal.xml
+++ b/app/src/main/res/layout/item_goal.xml
@@ -18,13 +18,14 @@
     </data>
 
     <FrameLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+                 android:layout_margin="16dp"
                  android:layout_width="match_parent"
                  android:layout_height="wrap_content">
 
         <ImageButton
                 android:id="@+id/ivGoalImage"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="@dimen/item_goal_height"
                 android:adjustViewBounds="true"
                 android:padding="0dp"
                 android:scaleType="centerCrop"
@@ -56,8 +57,8 @@
                 android:layout_gravity="bottom"
                 android:maxLines="1"
                 android:text='@{viewModel.title}'
-                android:textColor="@color/colorPrimary"
                 android:background="@color/colorWhiteOverlay"
+                android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
                 tools:text="Perperoni Pizza"
                 />
     </FrameLayout>

--- a/app/src/main/res/layout/item_idea.xml
+++ b/app/src/main/res/layout/item_idea.xml
@@ -35,6 +35,7 @@
                 android:text='@{viewModel.content}'
                 android:textColor="@color/colorText"
                 app:crossout='@{viewModel.crossedOut}'
+                android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
                 />
 
         <ImageButton

--- a/app/src/main/res/layout/single_plan.xml
+++ b/app/src/main/res/layout/single_plan.xml
@@ -1,13 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="wrap_content"
-    android:orientation="vertical" android:paddingTop="@dimen/activity_horizontal_margin">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView android:id="@+id/single_plan" android:layout_width="wrap_content" android:layout_height="wrap_content"
-        android:paddingBottom="5dp" android:textSize="25sp"
-        android:textStyle="bold" />
+    <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+                  android:orientation="horizontal"
+                  android:layout_margin="16dp"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content">
 
-    <TextView android:id="@+id/owner" android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        <ImageView
+                android:id="@+id/ivPlanImage"
+                android:layout_width="@dimen/item_idea_image_width"
+                android:layout_height="@dimen/item_idea_image_height"
+                android:adjustViewBounds="true"
+                android:padding="0dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/background_3"
+                />
 
-</LinearLayout>
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center_vertical"
+                android:orientation="vertical"
+                android:paddingTop="@dimen/activity_horizontal_margin"
+                >
+
+            <TextView
+                    android:id="@+id/single_plan"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="5dp"
+                    android:paddingLeft="10dp"
+                    android:paddingStart="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingEnd="10dp"
+                    android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
+                    tools:text="Grocery List"/>
+
+            <TextView
+                    android:id="@+id/owner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="11dp"
+                    android:paddingStart="11dp"
+                    android:paddingRight="11dp"
+                    android:paddingEnd="11dp"
+                    tools:text="pinyaoting"/>
+
+        </LinearLayout>
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -12,6 +12,10 @@
     <dimen name="fragment_idea_review_list_height">200dp</dimen>
     <dimen name="fragment_idea_preview_idea_selector_height">100dp</dimen>
     <dimen name="fragment_idea_preview_idea_selector_width">100dp</dimen>
+    <dimen name="item_goal_margin">16dp</dimen>
+    <dimen name="item_goal_height">300dp</dimen>
+    <dimen name="item_idea_image_width">100dp</dimen>
+    <dimen name="item_idea_image_height">100dp</dimen>
     <dimen name="border_width_thin">1dip</dimen>
     <dimen name="border_radius">4dip</dimen>
     <dimen name="border_width">5dip</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,4 +22,10 @@
         <item name="android:textColor">@color/colorButton</item>
     </style>
 
+    <style name="SearchBox">
+        <item name="android:textColor">@color/colorText</item>
+        <item name="android:textColorHint">@color/colorHint</item>
+        <item name="android:background">@drawable/border</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
@ShawnDuan @santhoshsachindran 
#77 #78

### Changelog
1. Enlarge the font in Grocery List.
2. Show grocery images in "Saved Grocery List" page. (The transition of the image is not ideal, issue #92 is created as a reminder to figure out a way to optimize it.)
3. Move "Explore Recipe" to the first page of the app, as a result, "Saved Grocery List" is on the second tab, and "Baookmarked Recipes" can be accessed by tapping on the floating action button in "Explore Recipe" page.
